### PR TITLE
Porting to support Terraform v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ It can be used directly from the Terraform Registry like so:
 ```
 module "gke-cluster" {
   source  = "jetstack/gke-cluster/google"
+<<<<<<< HEAD
   version = "0.1.0"
+=======
+  version = "0.2.0-alpha1"
+>>>>>>> Porting to support Terraform v0.12
 
   # insert the 9 required variables here
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -19,26 +19,27 @@ terraform {
   required_version = "~> 0.11"
 
   # Use a GCS Bucket as a backend
-  backend "gcs" {}
+  backend "gcs" {
+  }
 }
 
 # Local values assign a name to an expression, that can then be used multiple
 # times within a module. They are used here to determine the GCP region from
 # the given location, which can be either a region or zone.
 locals {
-  gcp_location_parts = ["${split("-", var.gcp_location)}"]
-  gcp_region         = "${local.gcp_location_parts[0]}-${local.gcp_location_parts[1]}"
+  gcp_location_parts = split("-", var.gcp_location)
+  gcp_region         = format("%s-%s", local.gcp_location_parts[0], local.gcp_location_parts[1])
 }
 
 # https://www.terraform.io/docs/providers/google/index.html
 provider "google" {
   version = "2.5.1"
-  project = "${var.gcp_project_id}"
-  region  = "${local.gcp_region}"
+  project = var.gcp_project_id
+  region  = local.gcp_region
 }
 
 resource "google_compute_network" "vpc_network" {
-  name                    = "${var.vpc_network_name}"
+  name                    = var.vpc_network_name
   auto_create_subnetworks = "false"
 }
 
@@ -52,28 +53,26 @@ resource "google_compute_subnetwork" "vpc_subnetwork" {
   # a dash, lowercase letter, or digit, except the last character, which
   # cannot be a dash.
   #name = "default-${var.gcp_cluster_region}"
-  name = "${var.vpc_subnetwork_name}"
+  name = var.vpc_subnetwork_name
 
-  ip_cidr_range = "${var.vpc_subnetwork_cidr_range}"
+  ip_cidr_range = var.vpc_subnetwork_cidr_range
 
   # The network this subnet belongs to. Only networks that are in the
   # distributed mode can have subnetworks.
-  network = "${var.vpc_network_name}"
+  network = var.vpc_network_name
 
   # An array of configurations for secondary IP ranges for VM instances
   # contained in this subnetwork. The primary IP of such VM must belong to the
   # primary ipCidrRange of the subnetwork. The alias IPs may belong to either
   # primary or secondary ranges.
-  secondary_ip_range = [
-    {
-      range_name    = "${var.cluster_secondary_range_name}"
-      ip_cidr_range = "${var.cluster_secondary_range_cidr}"
-    },
-    {
-      range_name    = "${var.services_secondary_range_name}"
-      ip_cidr_range = "${var.services_secondary_range_cidr}"
-    },
-  ]
+  secondary_ip_range {
+    range_name    = var.cluster_secondary_range_name
+    ip_cidr_range = var.cluster_secondary_range_cidr
+  }
+  secondary_ip_range {
+    range_name    = var.services_secondary_range_name
+    ip_cidr_range = var.services_secondary_range_cidr
+  }
 
   # When enabled, VMs in this subnetwork without external IP addresses can
   # access Google APIs and services by using Private Google Access. This is
@@ -81,31 +80,31 @@ resource "google_compute_subnetwork" "vpc_subnetwork" {
   private_ip_google_access = true
 
   depends_on = [
-    "google_compute_network.vpc_network",
+    google_compute_network.vpc_network,
   ]
 }
 
 module "cluster" {
-  source  = "jetstack/gke-cluster/google"
-  version = "0.1.0-beta2"
+  source  = "../terraform-google-gke-cluster"
+  #version = "0.2.0-alpha1"
 
   # These values are set from the terrafrom.tfvas file
-  gcp_project_id                         = "${var.gcp_project_id}"
-  cluster_name                           = "${var.cluster_name}"
-  gcp_location                           = "${var.gcp_location}"
-  daily_maintenance_window_start_time    = "${var.daily_maintenance_window_start_time}"
-  node_pools                             = "${var.node_pools}"
-  cluster_secondary_range_name           = "${var.cluster_secondary_range_name}"
-  services_secondary_range_name          = "${var.services_secondary_range_name}"
-  master_ipv4_cidr_block                 = "${var.master_ipv4_cidr_block}"
-  access_private_images                  = "${var.access_private_images}"
-  http_load_balancing_disabled           = "${var.http_load_balancing_disabled}"
-  master_authorized_networks_cidr_blocks = "${var.master_authorized_networks_cidr_blocks}"
+  gcp_project_id                         = var.gcp_project_id
+  cluster_name                           = var.cluster_name
+  gcp_location                           = var.gcp_location
+  daily_maintenance_window_start_time    = var.daily_maintenance_window_start_time
+  node_pools                             = var.node_pools
+  cluster_secondary_range_name           = var.cluster_secondary_range_name
+  services_secondary_range_name          = var.services_secondary_range_name
+  master_ipv4_cidr_block                 = var.master_ipv4_cidr_block
+  access_private_images                  = var.access_private_images
+  http_load_balancing_disabled           = var.http_load_balancing_disabled
+  master_authorized_networks_cidr_blocks = var.master_authorized_networks_cidr_blocks
 
   # Refer to the vpc-network and vpc-subnetwork by the name value on the
   # resource, rather than the variable used to assign the name, so that
   # Terraform knows they must be created before creating the cluster
-  vpc_network_name = "${google_compute_network.vpc_network.name}"
 
-  vpc_subnetwork_name = "${google_compute_subnetwork.vpc_subnetwork.name}"
+  vpc_network_name    = google_compute_network.vpc_network.name
+  vpc_subnetwork_name = google_compute_subnetwork.vpc_subnetwork.name
 }

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 variable "gcp_project_id" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The ID of the project in which the resources belong.
@@ -21,7 +21,7 @@ EOF
 }
 
 variable "cluster_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the cluster, unique within the project and zone.
@@ -29,7 +29,7 @@ EOF
 }
 
 variable "gcp_location" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The location (region or zone) in which the cluster master will be created,
@@ -46,7 +46,7 @@ EOF
 }
 
 variable "daily_maintenance_window_start_time" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The start time of the 4 hour window for daily maintenance operations RFC3339
@@ -55,7 +55,7 @@ EOF
 }
 
 variable "node_pools" {
-  type = "list"
+  type = list(map(string))
 
   description = <<EOF
 The list of node pool configurations, each should include:
@@ -96,7 +96,7 @@ EOF
 }
 
 variable "vpc_network_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the Google Compute Engine network to which the cluster is
@@ -105,7 +105,7 @@ EOF
 }
 
 variable "vpc_subnetwork_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the Google Compute Engine subnetwork in which the cluster's
@@ -114,11 +114,11 @@ EOF
 }
 
 variable "vpc_subnetwork_cidr_range" {
-  type = "string"
+  type = string
 }
 
 variable "cluster_secondary_range_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the secondary range to be used as for the cluster CIDR block.
@@ -128,11 +128,11 @@ EOF
 }
 
 variable "cluster_secondary_range_cidr" {
-  type = "string"
+  type = string
 }
 
 variable "services_secondary_range_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the secondary range to be used as for the services CIDR block.
@@ -142,11 +142,11 @@ EOF
 }
 
 variable "services_secondary_range_cidr" {
-  type = "string"
+  type = string
 }
 
 variable "master_ipv4_cidr_block" {
-  type    = "string"
+  type = string
   default = "172.16.0.0/28"
 
   description = <<EOF
@@ -158,7 +158,7 @@ EOF
 }
 
 variable "access_private_images" {
-  type    = "string"
+  type    = string
   default = "false"
 
   description = <<EOF
@@ -168,7 +168,7 @@ EOF
 }
 
 variable "http_load_balancing_disabled" {
-  type    = "string"
+  type = string
   default = "false"
 
   description = <<EOF
@@ -179,18 +179,19 @@ EOF
 }
 
 variable "master_authorized_networks_cidr_blocks" {
-  type = "list"
+  type = list(map(string))
 
-  default = [{
-    # External network that can access Kubernetes master through HTTPS. Must
-    # be specified in CIDR notation. This block should allow access from any
-    # address, but is given explicitly to prevernt Google's defaults from
-    # fighting with Terraform.
-    cidr_block = "0.0.0.0/0"
-
-    # Field for users to identify CIDR blocks.
-    display_name = "default"
-  }]
+  default = [
+    {
+      # External network that can access Kubernetes master through HTTPS. Must
+      # be specified in CIDR notation. This block should allow access from any
+      # address, but is given explicitly to prevernt Google's defaults from
+      # fighting with Terraform.
+      cidr_block = "0.0.0.0/0"
+      # Field for users to identify CIDR blocks.
+      display_name = "default"
+    },
+  ]
 
   description = <<EOF
 Defines up to 20 external networks that can access Kubernetes master

--- a/iam.tf
+++ b/iam.tf
@@ -44,7 +44,7 @@ resource "google_project_iam_member" "monitoring-viewer" {
 }
 
 resource "google_project_iam_member" "storage-object-viewer" {
-  count  = "${var.access_private_images == "true" ? 1 : 0}"
+  count  = var.access_private_images == "true" ? 1 : 0
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.default.email}"
 }

--- a/main.tf
+++ b/main.tf
@@ -29,22 +29,22 @@ terraform {
 # times within a module. They are used here to determine the GCP region from
 # the given location, which can be either a region or zone.
 locals {
-  gcp_location_parts = ["${split("-", var.gcp_location)}"]
-  gcp_region         = "${local.gcp_location_parts[0]}-${local.gcp_location_parts[1]}"
+  gcp_location_parts = split("-", var.gcp_location)
+  gcp_region         = format("%s-%s", local.gcp_location_parts[0], local.gcp_location_parts[1]) 
 }
 
 # https://www.terraform.io/docs/providers/google/index.html
 provider "google" {
   version = "2.5.1"
-  project = "${var.gcp_project_id}"
-  region  = "${local.gcp_region}"
+  project = var.gcp_project_id
+  region  = local.gcp_region
 }
 
 # https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "cluster" {
-  location = "${var.gcp_location}"
+  location = var.gcp_location
 
-  name = "${var.cluster_name}"
+  name = var.cluster_name
 
   # The minimum version of the master. GKE will auto-update the master to new
   # versions, so this does not guarantee the current master version--use the
@@ -58,7 +58,7 @@ resource "google_container_cluster" "cluster" {
 
   maintenance_policy {
     daily_maintenance_window {
-      start_time = "${var.daily_maintenance_window_start_time}"
+      start_time = var.daily_maintenance_window_start_time
     }
   }
 
@@ -72,7 +72,7 @@ resource "google_container_cluster" "cluster" {
     # private networking.
     enable_private_nodes = true
 
-    master_ipv4_cidr_block = "${var.master_ipv4_cidr_block}"
+    master_ipv4_cidr_block = var.master_ipv4_cidr_block
   }
 
   # Configuration options for the NetworkPolicy feature.
@@ -106,7 +106,7 @@ resource "google_container_cluster" "cluster" {
     }
 
     http_load_balancing {
-      disabled = "${var.http_load_balancing_disabled}"
+      disabled = var.http_load_balancing_disabled
     }
 
     # Whether we should enable the network policy addon for the master. This must be
@@ -118,8 +118,8 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
-  network    = "${var.vpc_network_name}"
-  subnetwork = "${var.vpc_subnetwork_name}"
+  network    = var.vpc_network_name
+  subnetwork = var.vpc_subnetwork_name
 
   # Configuration for cluster IP allocation. As of now, only pre-allocated
   # subnetworks (custom type with secondary ranges) are supported. This will
@@ -131,8 +131,8 @@ resource "google_container_cluster" "cluster" {
     # false; afterwards, it's true.
     use_ip_aliases = true
 
-    cluster_secondary_range_name  = "${var.cluster_secondary_range_name}"
-    services_secondary_range_name = "${var.services_secondary_range_name}"
+    cluster_secondary_range_name  = var.cluster_secondary_range_name
+    services_secondary_range_name = var.services_secondary_range_name
   }
 
   # It's not possible to create a cluster with no node pool defined, but we
@@ -147,7 +147,18 @@ resource "google_container_cluster" "cluster" {
   # nested cidr_blocks attribute to disallow external access (except the
   # cluster node IPs, which GKE automatically whitelists).
   master_authorized_networks_config {
-    cidr_blocks = "${var.master_authorized_networks_cidr_blocks}"
+    dynamic "cidr_blocks" {
+      for_each = var.master_authorized_networks_cidr_blocks
+      content {
+        # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
+        # which keys might be set in maps assigned here, so it has
+        # produced a comprehensive set here. Consider simplifying
+        # this after confirming which keys can be set in practice.
+
+        cidr_block   = cidr_blocks.value.cidr_block
+        display_name = lookup(cidr_blocks.value, "display_name", null)
+      }
+    }
   }
 
   # Change how long update operations on the cluster are allowed to take
@@ -161,57 +172,73 @@ resource "google_container_cluster" "cluster" {
 # https://www.terraform.io/docs/providers/google/r/container_node_pool.html
 resource "google_container_node_pool" "node_pool" {
   # The location (region or zone) in which the cluster resides
-  location = "${google_container_cluster.cluster.location}"
+  location = google_container_cluster.cluster.location
 
-  count = "${length(var.node_pools)}"
+  count = length(var.node_pools)
 
   # The name of the node pool. Instance groups created will have the cluster
   # name prefixed automatically.
-  name = "${lookup(var.node_pools[count.index], "name", format("%03d", count.index + 1))}-pool"
+  name = format("%s-pool", lookup(var.node_pools[count.index], "name", format("%03d", count.index + 1)))
 
   # The cluster to create the node pool for.
-  cluster = "${google_container_cluster.cluster.name}"
+  cluster = google_container_cluster.cluster.name
 
-  initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", 1)}"
+  initial_node_count = lookup(var.node_pools[count.index], "initial_node_count", 1)
 
   # Configuration required by cluster autoscaler to adjust the size of the node pool to the current cluster usage.
   autoscaling {
     # Minimum number of nodes in the NodePool. Must be >=0 and <= max_node_count.
-    min_node_count = "${lookup(var.node_pools[count.index], "autoscaling_min_node_count", 2)}"
+    min_node_count = lookup(var.node_pools[count.index], "autoscaling_min_node_count", 2)
 
     # Maximum number of nodes in the NodePool. Must be >= min_node_count.
-    max_node_count = "${lookup(var.node_pools[count.index], "autoscaling_max_node_count", 3)}"
+    max_node_count = lookup(var.node_pools[count.index], "autoscaling_max_node_count", 3)
   }
 
   # Node management configuration, wherein auto-repair and auto-upgrade is configured.
-  management = {
+  management {
     # Whether the nodes will be automatically repaired.
-    auto_repair = "${lookup(var.node_pools[count.index], "auto_repair", true)}"
+    auto_repair = lookup(var.node_pools[count.index], "auto_repair", true)
 
     # Whether the nodes will be automatically upgraded.
-    auto_upgrade = "${lookup(var.node_pools[count.index], "auto_upgrade", true)}"
+    auto_upgrade = lookup(var.node_pools[count.index], "auto_upgrade", true)
   }
 
   # Parameters used in creating the cluster's nodes.
   node_config {
     # The name of a Google Compute Engine machine type. Defaults to
     # n1-standard-1.
-    machine_type = "${lookup(var.node_pools[count.index], "node_config_machine_type", "n1-standard-1")}"
+    machine_type = lookup(
+      var.node_pools[count.index],
+      "node_config_machine_type",
+      "n1-standard-1",
+    )
 
-    service_account = "${google_service_account.default.email}"
+    service_account = google_service_account.default.email
 
     # Size of the disk attached to each node, specified in GB. The smallest
     # allowed disk size is 10GB. Defaults to 100GB.
-    disk_size_gb = "${lookup(var.node_pools[count.index], "node_config_disk_size_gb", 100)}"
+    disk_size_gb = lookup(
+      var.node_pools[count.index],
+      "node_config_disk_size_gb",
+      100
+    )
 
     # Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd').
     # If unspecified, the default disk type is 'pd-standard'
-    disk_type = "${lookup(var.node_pools[count.index], "node_config_disk_type", "pd-standard")}"
+    disk_type = lookup(
+      var.node_pools[count.index],
+      "node_config_disk_type",
+      "pd-standard",
+    )
 
     # A boolean that represents whether or not the underlying node VMs are
     # preemptible. See the official documentation for more information.
     # Defaults to false.
-    preemptible = "${lookup(var.node_pools[count.index], "node_config_preemptible", false)}"
+    preemptible = lookup(
+      var.node_pools[count.index],
+      "node_config_preemptible",
+      false,
+    )
 
     # The set of Google API scopes to be made available on all of the node VMs
     # under the "default" service account. These can be either FQDNs, or scope
@@ -236,3 +263,4 @@ resource "google_container_node_pool" "node_pool" {
     update = "20m"
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -150,13 +150,8 @@ resource "google_container_cluster" "cluster" {
     dynamic "cidr_blocks" {
       for_each = var.master_authorized_networks_cidr_blocks
       content {
-        # TF-UPGRADE-TODO: The automatic upgrade tool can't predict
-        # which keys might be set in maps assigned here, so it has
-        # produced a comprehensive set here. Consider simplifying
-        # this after confirming which keys can be set in practice.
-
         cidr_block   = cidr_blocks.value.cidr_block
-        display_name = lookup(cidr_blocks.value, "display_name", null)
+        display_name = cidr_blocks.value.display_name
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 variable "gcp_project_id" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The ID of the project in which the resources belong.
@@ -21,7 +21,7 @@ EOF
 }
 
 variable "cluster_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the cluster, unique within the project and zone.
@@ -29,7 +29,7 @@ EOF
 }
 
 variable "gcp_location" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The location (region or zone) in which the cluster master will be created,
@@ -46,7 +46,7 @@ EOF
 }
 
 variable "daily_maintenance_window_start_time" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The start time of the 4 hour window for daily maintenance operations RFC3339
@@ -55,7 +55,7 @@ EOF
 }
 
 variable "node_pools" {
-  type = "list"
+  type = list(map(string))
 
   description = <<EOF
 The list of node pool configurations, each should include:
@@ -96,7 +96,7 @@ EOF
 }
 
 variable "vpc_network_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the Google Compute Engine network to which the cluster is
@@ -105,7 +105,7 @@ EOF
 }
 
 variable "vpc_subnetwork_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the Google Compute Engine subnetwork in which the cluster's
@@ -114,7 +114,7 @@ EOF
 }
 
 variable "cluster_secondary_range_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the secondary range to be used as for the cluster CIDR block.
@@ -124,7 +124,7 @@ EOF
 }
 
 variable "services_secondary_range_name" {
-  type = "string"
+  type = string
 
   description = <<EOF
 The name of the secondary range to be used as for the services CIDR block.
@@ -134,7 +134,7 @@ EOF
 }
 
 variable "master_ipv4_cidr_block" {
-  type    = "string"
+  type = string
   default = "172.16.0.0/28"
 
   description = <<EOF
@@ -146,7 +146,7 @@ EOF
 }
 
 variable "access_private_images" {
-  type    = "string"
+  type    = string
   default = "false"
 
   description = <<EOF
@@ -156,7 +156,7 @@ EOF
 }
 
 variable "http_load_balancing_disabled" {
-  type    = "string"
+  type = string
   default = "false"
 
   description = <<EOF
@@ -167,18 +167,19 @@ EOF
 }
 
 variable "master_authorized_networks_cidr_blocks" {
-  type = "list"
+  type = list(map(string))
 
-  default = [{
-    # External network that can access Kubernetes master through HTTPS. Must
-    # be specified in CIDR notation. This block should allow access from any
-    # address, but is given explicitly to prevernt Google's defaults from
-    # fighting with Terraform.
-    cidr_block = "0.0.0.0/0"
-
-    # Field for users to identify CIDR blocks.
-    display_name = "default"
-  }]
+  default = [
+    {
+      # External network that can access Kubernetes master through HTTPS. Must
+      # be specified in CIDR notation. This block should allow access from any
+      # address, but is given explicitly to prevernt Google's defaults from
+      # fighting with Terraform.
+      cidr_block = "0.0.0.0/0"
+      # Field for users to identify CIDR blocks.
+      display_name = "default"
+    },
+  ]
 
   description = <<EOF
 Defines up to 20 external networks that can access Kubernetes master

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Because of breaking issue between v0.11 and v0.12 this change would require some level of version forking.  The port needs more testing and the docs will need to be updated to reference the correct version number for the future module.

This v0.12 version can be tested by creating a local module much like the `example` in the project and changing the path to reference the folder.