### PR TITLE
Set terraform required version

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 0.11.8"
+  # This project requires a terraform version >= 0.11 but < 0.12. This is
+  # because the module is only tested with 0.11 ,and has not yet been upgraded
+  # to use the new 0.12 syntax.
+  required_version = "~> 0.11"
 
   # Use a GCS Bucket as a backend
   backend "gcs" {}

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,13 @@
 # documentation. Arguments set by input variables are documented in the
 # variables.tf file.
 
+terraform {
+  # This module requires a terraform version >= 0.11 but < 0.12. This is
+  # because the module is only tested with 0.11 ,and has not yet been upgraded
+  # to use the new 0.12 syntax.
+  required_version = "~> 0.11"
+}
+
 # Local values assign a name to an expression, that can then be used multiple
 # times within a module. They are used here to determine the GCP region from
 # the given location, which can be either a region or zone.


### PR DESCRIPTION
The module and example should explicitly specify a required Terraform version, especially with that changes that 0.12 introduces.