### PR TITLE
Stackdriver logging and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These are:
 - Disable HTTP load balancing (defaults to false, i.e. HTTP load balancing is enabled)
 - Master CIDR block (defaults to 172.16.0.0/28)
 - Master authorized CIDR blocks (defaults to 0.0.0.0/0 i.e. everywhere)
+- Enabling Stackdriver Kubernetes logging and monitoring
 
 Note that the VPC network and subnetwork specified must already exist.
 The subnetwork must also have the cluster and service ranges specified.

--- a/main.tf
+++ b/main.tf
@@ -166,6 +166,16 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
+  # The loggingservice that the cluster should write logs to. Using the
+  # 'logging.googleapis.com/kubernetes' option makes use of new Stackdriver
+  # Kubernetes integration.
+  logging_service = var.stackdriver_logging != "false" ? "logging.googleapis.com/kubernetes" : ""
+
+  # The monitoring service that the cluster should write metrics to. Using the
+  # 'monitoring.googleapis.com/kubernetes' option makes use of new Stackdriver
+  # Kubernetes integration.
+  monitoring_service = var.stackdriver_monitoring != "false" ? "monitoring.googleapis.com/kubernetes" : ""
+
   # Change how long update operations on the cluster are allowed to take
   # before being considered to have failed. The default is 10 mins.
   # https://www.terraform.io/docs/configuration/resources.html#operation-timeouts

--- a/variables.tf
+++ b/variables.tf
@@ -173,7 +173,7 @@ variable "master_authorized_networks_cidr_blocks" {
     {
       # External network that can access Kubernetes master through HTTPS. Must
       # be specified in CIDR notation. This block should allow access from any
-      # address, but is given explicitly to prevernt Google's defaults from
+      # address, but is given explicitly to prevent Google's defaults from
       # fighting with Terraform.
       cidr_block = "0.0.0.0/0"
       # Field for users to identify CIDR blocks.
@@ -257,7 +257,7 @@ variable "stackdriver_monitoring" {
   default = "true"
 
   description = <<EOF
-Whether Stackdriver Kubernetes montioring is enabled. This should only be set to
-"false" if another montioring solution is set up.
+Whether Stackdriver Kubernetes monitoring is enabled. This should only be set to
+"false" if another monitoring solution is set up.
 EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -241,3 +241,23 @@ Kubernetes RBAC. Group name must be in format
 gke-security-groups@yourdomain.com.
 EOF
 }
+
+variable "stackdriver_logging" {
+  type    = "string"
+  default = "true"
+
+  description = <<EOF
+Whether Stackdriver Kubernetes logging is enabled. This should only be set to
+"false" if another logging solution is set up.
+EOF
+}
+
+variable "stackdriver_monitoring" {
+  type    = "string"
+  default = "true"
+
+  description = <<EOF
+Whether Stackdriver Kubernetes montioring is enabled. This should only be set to
+"false" if another montioring solution is set up.
+EOF
+}


### PR DESCRIPTION
Add logging and monitoring services specification to use new Kubernetes Stackdriver integration.

Closes #40.