### PR TITLE
Update example according to the latest release (v0.1.0)

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -87,7 +87,7 @@ resource "google_compute_subnetwork" "vpc_subnetwork" {
 
 module "cluster" {
   source  = "jetstack/gke-cluster/google"
-  version = "0.1.0-beta2"
+  version = "0.1.0"
 
   # These values are set from the terrafrom.tfvas file
   gcp_project_id                         = "${var.gcp_project_id}"


### PR DESCRIPTION
As a newcomer to this terraform module, I've followed the example steps and had following errors during 'terraform apply' process:

```
Error: Error applying plan:

1 error(s) occurred:

* module.cluster.google_container_cluster.cluster: 1 error(s) occurred:

* google_container_cluster.cluster: project: required field is not set
```

Setting module version to 0.1.0 solve the problem (according to the latest release).