### PR TITLE
Update verify script

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -5,7 +5,7 @@ This example project gives the minimum Terraform setup required to use the `terr
 ## Prerequisites
 
 Check that Terraform is installed and up to date on your machine with `terraform version`.
-At the time of writing the version of binary distributed by HashiCorp is `v0.12.12`.
+At the time of writing the version of binary distributed by HashiCorp is `v0.12.20`.
 Installation instructions can be found [here](https://learn.hashicorp.com/terraform/getting-started/install.html).
 
 This guide uses the Google Cloud Platform (GCP) utility `gcloud`, which is part of the [Cloud SDK](https://cloud.google.com/sdk/).

--- a/example/README.md
+++ b/example/README.md
@@ -5,7 +5,7 @@ This example project gives the minimum Terraform setup required to use the `terr
 ## Prerequisites
 
 Check that Terraform is installed and up to date on your machine with `terraform version`.
-At the time of writing the version of binary distributed by HashiCorp is `v0.12.20`.
+At the time of writing the version of binary distributed by HashiCorp is `v0.12.24`.
 Installation instructions can be found [here](https://learn.hashicorp.com/terraform/getting-started/install.html).
 
 This guide uses the Google Cloud Platform (GCP) utility `gcloud`, which is part of the [Cloud SDK](https://cloud.google.com/sdk/).

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -50,7 +50,7 @@ fi
 # Checks the Terraform version used by the module, download the Terraform binary
 # for that version
 if grep "required_version.*0.12.*" "${REPO_ROOT}/main.tf"; then
-    TERRAFORM_VERSION="0.12.4"
+    TERRAFORM_VERSION="0.12.20"
 else
     echo "Terraform version is not supported or could not be found."
     exit 1

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -56,8 +56,13 @@ else
     exit 1
 fi
 
-curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TERRAFORM_OS}_${TERRAFORM_ARCH}.zip" -o terraform.zip
-unzip terraform.zip
+TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_${TERRAFORM_OS}_${TERRAFORM_ARCH}.zip"
+TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/${TERRAFORM_ZIP}"
+# If the zip is already present don't download it again.
+if [ ! -f ${TERRAFORM_ZIP} ]; then
+    curl $TERRAFORM_URL -o $TERRAFORM_ZIP
+fi
+unzip -o $TERRAFORM_ZIP
 chmod +x terraform
 TERRAFORM="${VERIFY_DIR}/terraform"
 $TERRAFORM version

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -79,7 +79,7 @@ cp "${REPO_ROOT}/example/terraform.tfvars.example" terraform.tfvars
 # Remove the requirement for a GCS backend so we can init and validate locally
 perl -i -0pe 's/(\s*)backend "gcs" \{\n?\s*\n?\s*\}/\1# GCS bucket not used for testing/gms' main.tf
 # Use the local version of the module, not the Terraform Registry version, and remove the version specification
-perl -i -0pe 's/(\s*)source*\s*= "jetstack\/gke-cluster\/google"\n\s*version = "0.2.0-alpha1"/\1source = "..\/"/gms' main.tf
+perl -i -0pe 's/(\s*)source*\s*= "jetstack\/gke-cluster\/google"\n\s*version = ".*"/\1source = "..\/"/gms' main.tf
 
 # Initialise and validate the generated test project
 $TERRAFORM init

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -50,7 +50,7 @@ fi
 # Checks the Terraform version used by the module, download the Terraform binary
 # for that version
 if grep "required_version.*0.12.*" "${REPO_ROOT}/main.tf"; then
-    TERRAFORM_VERSION="0.12.20"
+    TERRAFORM_VERSION="0.12.24"
 else
     echo "Terraform version is not supported or could not be found."
     exit 1

--- a/variables.tf
+++ b/variables.tf
@@ -134,7 +134,7 @@ EOF
 }
 
 variable "master_ipv4_cidr_block" {
-  type = string
+  type    = string
   default = "172.16.0.0/28"
 
   description = <<EOF
@@ -156,7 +156,7 @@ EOF
 }
 
 variable "http_load_balancing_disabled" {
-  type = string
+  type    = string
   default = "false"
 
   description = <<EOF


### PR DESCRIPTION
- Change regex from hardcoded version to any value when changing module source for local testing. Closes #54.
- Adds a check to skip downloading Terraform binary if a zip is already present. This is useful during local testing to speed up successive runs of `verify.sh` when fixing a failure.
- Update Terraform version to latest.