### PR TITLE
Add flag for security groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,10 @@ locals {
   min_master_version = var.release_channel == "" ? var.min_master_version : ""
 }
 
+locals {
+  authenticator_security_group = var.authenticator_security_group == "" ? [] : [var.authenticator_security_group]
+}
+
 # https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "cluster" {
   location = var.gcp_location
@@ -63,6 +67,14 @@ resource "google_container_cluster" "cluster" {
 
     content {
       channel = release_channel.value
+    }
+  }
+
+  dynamic "authenticator_groups_config" {
+    for_each = toset(local.authenticator_security_group)
+
+    content {
+      security_group = authenticator_groups_config.value
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -229,3 +229,15 @@ business, stability, and functionality needs.
 EOF
 
 }
+
+variable "authenticator_security_group" {
+  type = string
+
+  default = ""
+
+  description = <<EOF
+The name of the RBAC security group for use with Google security groups in
+Kubernetes RBAC. Group name must be in format
+gke-security-groups@yourdomain.com.
+EOF
+}


### PR DESCRIPTION
If configured this allows to use GSuite groups within Kubernetes RBAC
bindings.

Closes #39 

Signed-off-by: Christian Simon <simon@swine.de>