### PR TITLE
Add support for release_channels

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -204,3 +204,28 @@ docs describe the various acceptable formats for this field.
 EOF
 
 }
+
+variable "release_channel" {
+  type = string
+
+  default = ""
+
+  description = <<EOF
+Kubernetes releases updates often, to deliver security updates, fix known
+issues, and introduce new features. Release channels provide control over how
+often clusters are automatically updated , and offer customers the ability to
+balance between stability and functionality of the version deployed in the
+cluster.
+
+When you enroll a new cluster in a release channel, Google automatically
+manages the version and upgrade cadence for the cluster and its node pools. All
+channels offer supported releases of GKE and are considered GA (although
+individual features may not always be GA, as marked). The Kubernetes releases
+in these channels are official Kubernetes releases and include both GA and beta
+Kubernetes APIs (as marked). New Kubernetes versions are first released to the
+Rapid channel, and over time will be promoted to the Regular, and Stable
+channel. This allows you to subscribe your cluster to a channel that meets your
+business, stability, and functionality needs.
+EOF
+
+}


### PR DESCRIPTION
This needs beta features and we have to swap out the provider for the
beta provider. A simple test didn't show any problems with existing
clusters of a previous verison of the module.

@reviewers: It is probably worth testing the behavrour manually, to ensure we are not breaking anything

Signed-off-by: Christian Simon <simon@swine.de>