### PR TITLE
Node version flag docs and auto_upgrade override

### DIFF
--- a/example/variables.tf
+++ b/example/variables.tf
@@ -58,7 +58,7 @@ variable "node_pools" {
   type = list(map(string))
 
   description = <<EOF
-The list of node pool configurations, each should include:
+The list of node pool configurations, each can include:
 
 name - The name of the node pool, which will be suffixed with '-pool'.
 Defaults to pool number in the Terraform list, starting from 1.
@@ -77,6 +77,14 @@ Defaults to 'true'.
 
 management_auto_upgrade - Whether the nodes will be automatically upgraded.
 Defaults to 'true'.
+
+version - The Kubernetes version for the nodes in this pool. Note that if this
+field is set the 'management_auto_upgrade' will be overriden and set to 'false'.
+This is to avoid both options fighting on what the node version should be. While
+a fuzzy version can be specified, it's recommended that you specify explicit
+versions as Terraform will see spurious diffs when fuzzy versions are used. See
+the 'google_container_engine_versions' data source's 'version_prefix' field to
+approximate fuzzy versions in a Terraform-compatible way.
 
 node_config_machine_type - The name of a Google Compute Engine machine type.
 Defaults to n1-standard-1. To create a custom machine type, value should be

--- a/main.tf
+++ b/main.tf
@@ -187,7 +187,7 @@ resource "google_container_node_pool" "node_pool" {
     max_node_count = lookup(var.node_pools[count.index], "autoscaling_max_node_count", 3)
   }
 
-  # Target a specific version
+  # Target a specific Kubernetes version.
   version = lookup(var.node_pools[count.index], "version", "")
 
   # Node management configuration, wherein auto-repair and auto-upgrade is configured.
@@ -196,7 +196,7 @@ resource "google_container_node_pool" "node_pool" {
     auto_repair = lookup(var.node_pools[count.index], "auto_repair", true)
 
     # Whether the nodes will be automatically upgraded.
-    auto_upgrade = lookup(var.node_pools[count.index], "auto_upgrade", true)
+    auto_upgrade = lookup(var.node_pools[count.index], "version", "") == "" ? lookup(var.node_pools[count.index], "auto_upgrade", true) : false
   }
 
   # Parameters used in creating the cluster's nodes.

--- a/variables.tf
+++ b/variables.tf
@@ -58,7 +58,7 @@ variable "node_pools" {
   type = list(map(string))
 
   description = <<EOF
-The list of node pool configurations, each should include:
+The list of node pool configurations, each can include:
 
 name - The name of the node pool, which will be suffixed with '-pool'.
 Defaults to pool number in the Terraform list, starting from 1.
@@ -77,6 +77,14 @@ Defaults to 'true'.
 
 management_auto_upgrade - Whether the nodes will be automatically upgraded.
 Defaults to 'true'.
+
+version - The Kubernetes version for the nodes in this pool. Note that if this
+field is set the 'management_auto_upgrade' will be overriden and set to 'false'.
+This is to avoid both options fighting on what the node version should be. While
+a fuzzy version can be specified, it's recommended that you specify explicit
+versions as Terraform will see spurious diffs when fuzzy versions are used. See
+the 'google_container_engine_versions' data source's 'version_prefix' field to
+approximate fuzzy versions in a Terraform-compatible way.
 
 node_config_machine_type - The name of a Google Compute Engine machine type.
 Defaults to n1-standard-1. To create a custom machine type, value should be


### PR DESCRIPTION
This is a follow up PR to #67 that adds documentation to for the `version` option in the `node_pool` configuration. It also forces the `management_auto_upgrade` to `false` if a `version` is set to prevent the two options from fighting as described in the Terraform docs:

> The Kubernetes version for the nodes in this pool. Note that if this field and auto_upgrade are  both specified, they will fight each other for what the node version should be, so setting both is highly discouraged.

https://www.terraform.io/docs/providers/google/r/container_node_pool.html#version