### PR TITLE
Add option to enable PodSecurityPolicy controller

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -131,6 +131,7 @@ module "cluster" {
   master_authorized_networks_cidr_blocks = var.master_authorized_networks_cidr_blocks
   private_nodes                          = var.private_nodes
   private_endpoint                       = var.private_endpoint
+  pod_security_policy_enabled            = var.pod_security_policy_enabled
 
   # Refer to the vpc-network and vpc-subnetwork by the name value on the
   # resource, rather than the variable used to assign the name, so that

--- a/example/main.tf
+++ b/example/main.tf
@@ -28,7 +28,7 @@ locals {
 }
 
 # https://www.terraform.io/docs/providers/google/index.html
-provider "google-beta" {
+provider "google" {
   version = "3.5.0"
   project = var.gcp_project_id
   region  = local.gcp_region

--- a/example/main.tf
+++ b/example/main.tf
@@ -28,7 +28,7 @@ locals {
 }
 
 # https://www.terraform.io/docs/providers/google/index.html
-provider "google" {
+provider "google-beta" {
   version = "3.5.0"
   project = var.gcp_project_id
   region  = local.gcp_region
@@ -50,7 +50,9 @@ resource "google_compute_subnetwork" "vpc_subnetwork" {
   # a dash, lowercase letter, or digit, except the last character, which
   # cannot be a dash.
   #name = "default-${var.gcp_cluster_region}"
-  name = var.vpc_subnetwork_name
+  name    = var.vpc_subnetwork_name
+  region  = local.gcp_region
+  project = var.gcp_project_id
 
   ip_cidr_range = var.vpc_subnetwork_cidr_range
 
@@ -113,7 +115,7 @@ resource "google_compute_router_nat" "nat" {
 
 module "cluster" {
   source  = "jetstack/gke-cluster/google"
-  version = "0.2.0-alpha1"
+  version = "0.2.1-alpha1"
 
   # These values are set from the terrafrom.tfvas file
   gcp_project_id                         = var.gcp_project_id

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -253,3 +253,25 @@ Defines up to 20 external networks that can access Kubernetes master
 through HTTPS.
 EOF
 }
+
+variable "pod_security_policy_enabled" {
+  type = bool
+
+  default = false
+
+  description = <<EOF
+A PodSecurityPolicy is an admission controller resource you create that
+validates requests to create and update Pods on your cluster. The
+PodSecurityPolicy resource defines a set of conditions that Pods must meet to be
+accepted by the cluster; when a request to create or update a Pod does not meet
+the conditions in the PodSecurityPolicy, that request is rejected and an error
+is returned.
+
+If you enable the PodSecurityPolicy controller without first defining and
+authorizing any actual policies, no users, controllers, or service accounts can
+create or update Pods. If you are working with an existing cluster, you should
+define and authorize policies before enabling the controller.
+
+https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies
+EOF
+}

--- a/iam.tf
+++ b/iam.tf
@@ -23,6 +23,8 @@ resource "random_id" "entropy" {
 
 # https://www.terraform.io/docs/providers/google/r/google_service_account.html
 resource "google_service_account" "default" {
+  provider = google
+
   account_id   = "cluster-minimal-${random_id.entropy.hex}"
   display_name = "Minimal service account for GKE cluster ${var.cluster_name}"
   project      = var.gcp_project_id
@@ -30,24 +32,32 @@ resource "google_service_account" "default" {
 
 # https://www.terraform.io/docs/providers/google/r/google_project_iam.html
 resource "google_project_iam_member" "logging-log-writer" {
+  provider = google
+
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.default.email}"
   project = var.gcp_project_id
 }
 
 resource "google_project_iam_member" "monitoring-metric-writer" {
+  provider = google
+
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.default.email}"
   project = var.gcp_project_id
 }
 
 resource "google_project_iam_member" "monitoring-viewer" {
+  provider = google
+
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.default.email}"
   project = var.gcp_project_id
 }
 
 resource "google_project_iam_member" "storage-object-viewer" {
+  provider = google
+
   count   = var.access_private_images == "true" ? 1 : 0
   role    = "roles/storage.objectViewer"
   member  = "serviceAccount:${google_service_account.default.email}"

--- a/iam.tf
+++ b/iam.tf
@@ -30,22 +30,26 @@ resource "google_service_account" "default" {
 
 # https://www.terraform.io/docs/providers/google/r/google_project_iam.html
 resource "google_project_iam_member" "logging-log-writer" {
-  role   = "roles/logging.logWriter"
-  member = "serviceAccount:${google_service_account.default.email}"
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.default.email}"
+  project = var.gcp_project_id
 }
 
 resource "google_project_iam_member" "monitoring-metric-writer" {
-  role   = "roles/monitoring.metricWriter"
-  member = "serviceAccount:${google_service_account.default.email}"
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.default.email}"
+  project = var.gcp_project_id
 }
 
 resource "google_project_iam_member" "monitoring-viewer" {
-  role   = "roles/monitoring.viewer"
-  member = "serviceAccount:${google_service_account.default.email}"
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.default.email}"
+  project = var.gcp_project_id
 }
 
 resource "google_project_iam_member" "storage-object-viewer" {
-  count  = var.access_private_images == "true" ? 1 : 0
-  role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.default.email}"
+  count   = var.access_private_images == "true" ? 1 : 0
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.default.email}"
+  project = var.gcp_project_id
 }

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,11 @@ resource "google_container_cluster" "cluster" {
     master_ipv4_cidr_block = var.master_ipv4_cidr_block
   }
 
+  # Enable the PodSecurityPolicy admission controller for the cluster.
+  pod_security_policy_config {
+    enabled = true
+  }
+
   # Configuration options for the NetworkPolicy feature.
   network_policy {
     # Whether network policy is enabled on the cluster. Defaults to false.
@@ -181,6 +186,8 @@ resource "google_container_cluster" "cluster" {
 
 # https://www.terraform.io/docs/providers/google/r/container_node_pool.html
 resource "google_container_node_pool" "node_pool" {
+  provider = "google-beta"
+
   # The location (region or zone) in which the cluster resides
   location = google_container_cluster.cluster.location
 
@@ -276,4 +283,3 @@ resource "google_container_node_pool" "node_pool" {
     update = "20m"
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,10 @@ provider "google" {
   region  = local.gcp_region
 }
 
+# To make use of beta features the google-beta provider is also used. Only
+# resources that use beta features use the beta provider. All resources have
+# the provider set explicitly for clarity.
+# https://www.terraform.io/docs/providers/google/guides/provider_versions.html#using-the-google-beta-provider
 provider "google-beta" {
   version = "~> 3.5"
   project = var.gcp_project_id
@@ -54,13 +58,13 @@ locals {
 
 # https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "cluster" {
+  provider = google-beta
+
   location = var.gcp_location
 
   name = var.cluster_name
 
   min_master_version = local.min_master_version
-
-  provider = google-beta
 
   dynamic "release_channel" {
     for_each = toset(local.release_channel)
@@ -186,7 +190,7 @@ resource "google_container_cluster" "cluster" {
 
 # https://www.terraform.io/docs/providers/google/r/container_node_pool.html
 resource "google_container_node_pool" "node_pool" {
-  provider = "google-beta"
+  provider = google
 
   # The location (region or zone) in which the cluster resides
   location = google_container_cluster.cluster.location

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ resource "google_container_cluster" "cluster" {
 
   # Enable the PodSecurityPolicy admission controller for the cluster.
   pod_security_policy_config {
-    enabled = true
+    enabled = var.pod_security_policy_enabled
   }
 
   # Configuration options for the NetworkPolicy feature.

--- a/variables.tf
+++ b/variables.tf
@@ -307,9 +307,9 @@ EOF
 }
 
 variable "pod_security_policy_enabled" {
-  type = string
+  type = bool
 
-  default = "false"
+  default = false
 
   description = <<EOF
 A PodSecurityPolicy is an admission controller resource you create that

--- a/variables.tf
+++ b/variables.tf
@@ -305,3 +305,25 @@ only RFC 1918 private addresses and communicate with the master via private
 networking.
 EOF
 }
+
+variable "pod_security_policy_enabled" {
+  type = string
+
+  default = "false"
+
+  description = <<EOF
+A PodSecurityPolicy is an admission controller resource you create that
+validates requests to create and update Pods on your cluster. The
+PodSecurityPolicy resource defines a set of conditions that Pods must meet to be
+accepted by the cluster; when a request to create or update a Pod does not meet
+the conditions in the PodSecurityPolicy, that request is rejected and an error
+is returned.
+
+If you enable the PodSecurityPolicy controller without first defining and
+authorizing any actual policies, no users, controllers, or service accounts can
+create or update Pods. If you are working with an existing cluster, you should
+define and authorize policies before enabling the controller.
+
+https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies
+EOF
+}


### PR DESCRIPTION
This PR builds on Zee's PR #56 and closes #41.

This has been manually tested and confirmed to work. Terraform applies successfully and Pods can't be created in the cluster without a suitable `PodSecurityPolicy` and required `ClusterRole` and `ClusterRoleBinding`.